### PR TITLE
Update blog-admin-backend-hexo.el

### DIFF
--- a/blog-admin-backend-hexo.el
+++ b/blog-admin-backend-hexo.el
@@ -58,7 +58,7 @@ categories:
          (mapcar
           (lambda (append-path)
             "scan files with append-path"
-            (directory-files (blog-admin-backend--full-path append-path) t "^.*\\.\\(org\\|md\\|markdown\\)$"))
+            (directory-files (blog-admin-backend--full-path append-path) t "^[^.]*\\.\\(org\\|md\\|markdown\\)$"))
           (list posts-dir drafts-dir)
           )))
 


### PR DESCRIPTION
不扫描目录中的隐藏文件，特别是.#开头的临时文件。
当有文件修改后未保存产生临时文件如果 不在当前 目录只是链接 的话会产生错误，报错找不到文件，不显示列表。